### PR TITLE
Mention dependency on ansible-sshknownhosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ git clone https://github.com/weareinteractive/ansible-ssh.git weareinteractive
 ## Dependencies
 
 * Ansible >= 2.4
+* [sshknownhosts](https://github.com/bfmartin/ansible-sshknownhosts) installed in your `ANSIBLE_LIBRARY` path
 
 ## Variables
 


### PR DESCRIPTION
As I've just done a fresh install I reencountered issue #4 and the need to clone ansible-sshknownhosts.
To try and make this easier on anyone (including me) in future I'm adding it to this roles dependencies
in the README.