### PR TITLE
Load the ssh_known_hosts tasks dynamically

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,8 @@
     - ssh
     - ssh-config
 
-- import_tasks: known_hosts.yml
+- include_tasks: known_hosts.yml
+  when: ssh_known_hosts | length > 0
   tags:
     - system
     - networking


### PR DESCRIPTION
The ssh_known_hosts tasks depends on an external module `sshknownhosts`.
When a user forgets to install this module the role, or rather Ansible,
will throw an error. While correct and called for this limits the "just
works" and "batteries included" experience.

By including this task dynamically the task with the sshknownhosts
module call is only processed when the user specifies the
"ssh_known_hosts" variable explicity.