### PR TITLE
OpenBSD support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ ssh_pubkey_authentication: 'yes'
 ssh_password_authentication: 'yes'
 
 # start on boot
-ssh_service_enabled: yes
+ssh_service_enabled: true
 # current state: started, stopped
 ssh_service_state: started
 # system wide known hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,12 @@
 #   Subsystem: sftp /usr/lib/openssh/sftp-server
 #
 
+# variable fallback defaults
+# usually overridden from Play or distro specific vars file
+ssh_config: {}
+ssh_packages: []
+ssh_service: sshd
+
 # DEPRICATION NOTICE:
 # use the `ssh_config` map @see var/DISTRIBUTION/VERSION.yml
 ssh_port: [22]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,6 @@
 
 - name: restart ssh
   service:
-    name: ssh
+    name: "{{ ssh_service }}"
     state: restarted
   when: ssh_service_state != 'stopped'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
-# For more information about handlers see:
-# http://www.ansibleworks.com/docs/playbooks.html#handlers-running-operations-on-change
-#
+# handlers for ssh role
 
 - name: restart ssh
-  action: service name=ssh state=restarted
+  service:
+    name: ssh
+    state: restarted
   when: ssh_service_state != 'stopped'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,11 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
+    - name: OpenBSD
+      versions:
+        - 6.8
+        - 6.9
+  #
   # List tags for your role here, one per line. A tag is
   # a keyword that describes and categorizes the role.
   # Users find roles by searching for tags. Be sure to

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: weareinteractive
   company: We Are Interactive
   description: Configures ssh
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
   license: MIT
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,10 @@
 ---
 galaxy_info:
-  author: franklin <franklin@weareinteractive.com>
+  role_name: ssh
+  author: weareinteractive
   company: We Are Interactive
-  description: Congifures ssh
-  min_ansible_version: 2.4
+  description: Configures ssh
+  min_ansible_version: 2.5
   license: MIT
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,
@@ -18,81 +19,12 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
-  #  - name: EL
-  #    versions:
-  #      - all
-  #      - 5
-  #      - 6
-  #  - name: GenericUNIX
-  #    versions:
-  #      - all
-  #      - any
-  #  - name: Fedora
-  #    versions:
-  #      - all
-  #      - 16
-  #      - 17
-  #      - 18
-  #      - 19
-  #      - 20
-  #  - name: opensuse
-  #    versions:
-  #      - all
-  #      - 12.1
-  #      - 12.2
-  #      - 12.3
-  #      - 13.1
-  #      - 13.2
-  #  - name: GenericBSD
-  #    versions:
-  #      - all
-  #      - any
-  #  - name: FreeBSD
-  #    versions:
-  #      - all
-  #      - 8.0
-  #      - 8.1
-  #      - 8.2
-  #      - 8.3
-  #      - 8.4
-  #      - 9.0
-  #      - 9.1
-  #      - 9.1
-  #      - 9.2
     - name: Ubuntu
       versions:
         - all
-  #      - lucid
-  #      - maverick
-  #      - natty
-  #      - oneiric
-  #      - precise
-  #      - quantal
-  #      - raring
-  #      - saucy
-  #      - trusty
-  #  - name: SLES
-  #    versions:
-  #      - all
-  #      - 10SP3
-  #      - 10SP4
-  #      - 11
-  #      - 11SP1
-  #      - 11SP2
-  #      - 11SP3
-  #  - name: GenericLinux
-  #    versions:
-  #      - all
-  #      - any
     - name: Debian
       versions:
         - bullseye
-  #      - all
-  #      - etch
-  #      - lenny
-  #      - squeeze
-  #      - wheezy
-  #
   # List tags for your role here, one per line. A tag is
   # a keyword that describes and categorizes the role.
   # Users find roles by searching for tags. Be sure to

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -84,8 +84,9 @@ galaxy_info:
   #    versions:
   #      - all
   #      - any
-  #  - name: Debian
-  #    versions:
+    - name: Debian
+      versions:
+        - bullseye
   #      - all
   #      - etch
   #      - lenny

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,9 +1,9 @@
-
+---
 - name: Configuring sshd
   template:
     src: etc/ssh/sshd_config.j2
     dest: /etc/ssh/sshd_config
-    backup: yes
+    backup: true
     owner: root
     group: root
     mode: "0644"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,7 @@
 ---
 
 - name: Installing packages
-  apt:
-    name: "{{ packages }}"
+  package:
+    name: "{{ ssh_packages }}"
     state: present
-  vars:
-    packages:
-      - openssh-server
-      - openssh-client
+  when: ssh_packages | length > 0

--- a/tasks/known_hosts.yml
+++ b/tasks/known_hosts.yml
@@ -3,4 +3,4 @@
 - name: Registering known hosts
   sshknownhosts:
     host: "{{ item.name if item.name is defined else item }}"
-  with_items: "{{ ssh_known_hosts }}"
+  loop: "{{ ssh_known_hosts }}"

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -2,6 +2,6 @@
 
 - name: Configuring service
   service:
-    name: ssh
+    name: "{{ ssh_service }}"
     state: "{{ ssh_service_state }}"
     enabled: "{{ ssh_service_enabled }}"

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -6,7 +6,7 @@
     params:
       errors: ignore
       files:
-        - "{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.yml"
-        - "{{ ansible_distribution | lower }}.yml"
+        - "{{ ansible_facts.distribution | lower }}/{{ ansible_facts.distribution_release }}.yml"
+        - "{{ ansible_facts.distribution | lower }}.yml"
       paths:
         - 'vars'

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,8 +1,10 @@
 ---
 
 - name: Including variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution | lower }}.yml"
   when: ssh_config is not defined

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,10 +1,12 @@
 ---
 
-- name: Including variables
+- name: Including OS specific variables
   include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
+      errors: ignore
       files:
         - "{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.yml"
         - "{{ ansible_distribution | lower }}.yml"
-  when: ssh_config is not defined
+      paths:
+        - 'vars'

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,7 +1,6 @@
 ---
-
 - hosts: all
-  become: yes
+  become: true
   roles:
     - weareinteractive.ssh
   vars:
@@ -40,4 +39,3 @@
       AcceptEnv: LANG LC_*
       Subsystem: sftp /usr/lib/openssh/sftp-server
       UsePAM: "yes"
-

--- a/vars/debian/bullseye.yml
+++ b/vars/debian/bullseye.yml
@@ -1,0 +1,9 @@
+---
+ssh_config:
+  Include: /etc/ssh/sshd_config.d/*.conf
+  ChallengeResponseAuthentication: "no"
+  UsePAM: "yes"
+  X11Forwarding: "yes"
+  PrintMotd: "no"
+  AcceptEnv: LANG LC_*
+  Subsystem: sftp /usr/lib/openssh/sftp-server

--- a/vars/debian/bullseye.yml
+++ b/vars/debian/bullseye.yml
@@ -1,4 +1,11 @@
 ---
+ssh_packages:
+  - openssh-server
+  - openssh-client
+  - openssh-sftp-server
+
+ssh_service: ssh
+
 ssh_config:
   Include: /etc/ssh/sshd_config.d/*.conf
   ChallengeResponseAuthentication: "no"

--- a/vars/openbsd.yml
+++ b/vars/openbsd.yml
@@ -1,0 +1,8 @@
+---
+ssh_packages: []
+ssh_service: sshd
+
+ssh_config:
+  PermitRootLogin: "no"
+  AuthorizedKeysFile: .ssh/authorized_keys
+  Subsystem: sftp /usr/libexec/sftp-server

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,4 +1,10 @@
 ---
+ssh_packages:
+  - openssh-server
+  - openssh-client
+
+ssh_service: ssh
+
 ssh_config:
   ChallengeResponseAuthentication: "no"
   UsePAM: "yes"

--- a/vars/ubuntu/bionic.yml
+++ b/vars/ubuntu/bionic.yml
@@ -1,4 +1,10 @@
 ---
+ssh_packages:
+  - openssh-server
+  - openssh-client
+
+ssh_service: ssh
+
 ssh_config:
   Port: "{{ ssh_port }}"
   ListenAddress: "{{ ssh_listen_address }}"

--- a/vars/ubuntu/trusty.yml
+++ b/vars/ubuntu/trusty.yml
@@ -1,4 +1,10 @@
 ---
+ssh_packages:
+  - openssh-server
+  - openssh-client
+
+ssh_service: ssh
+
 ssh_config:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"

--- a/vars/ubuntu/trusty.yml
+++ b/vars/ubuntu/trusty.yml
@@ -1,3 +1,4 @@
+---
 ssh_config:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"

--- a/vars/ubuntu/xenial.yml
+++ b/vars/ubuntu/xenial.yml
@@ -1,4 +1,10 @@
 ---
+ssh_packages:
+  - openssh-server
+  - openssh-client
+
+ssh_service: ssh
+
 ssh_config:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"

--- a/vars/ubuntu/xenial.yml
+++ b/vars/ubuntu/xenial.yml
@@ -1,3 +1,4 @@
+---
 ssh_config:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"


### PR DESCRIPTION
This adds support for OpenBSD machines.
Introduces a variable (`ssh_packages`) to allow for dynamic selection of packages and one for the service name (`ssh_service`).
Adding other distributions is now a matter of adding their specific variants of those in a file in `vars/`.

This pull request follows #14 