### PR TITLE
Update Travis CI to use Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - git clone https://github.com/bfmartin/ansible-sshknownhosts.git library/sshknownhosts
 script:
   - echo localhost > inventory
-  - ln -s ansible-ssh ../weareinteractive.ssh
+  - ln -s "$PWD" ../weareinteractive.ssh
   - ansible-playbook --version
   - ansible-playbook --syntax-check -i inventory tests/main.yml
   - ansible-playbook -i inventory tests/main.yml --connection=local --become -vvvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
-
+os: linux
+dist: xenial
 language: python
-python: "2.7"
+python: "3.8"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt python-pycurl git

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 > `weareinteractive.ssh` is an [Ansible](http://www.ansible.com) role which:
 >
-> * installs ssh
-> * configures ssh
-> * adds logrotate for ssh container logs
+> * Installs OpenSSH (if required)
+> * Configures OpenSSH
+> * Ensures OpenSSH is running and started on boot
+
 
 **Note:**
 
@@ -37,8 +38,8 @@ $ git clone https://github.com/weareinteractive/ansible-ssh.git weareinteractive
 
 ## Dependencies
 
-* Ansible >= 2.4
-* [sshknownhosts](https://github.com/bfmartin/ansible-sshknownhosts) installed in your `ANSIBLE_LIBRARY` path (see [#4](https://github.com/weareinteractive/ansible-ssh/issues/4))
+* Ansible >= 2.9
+* [sshknownhosts](https://github.com/bfmartin/ansible-sshknownhosts) installed in your `ANSIBLE_LIBRARY` path (see [#4](https://github.com/weareinteractive/ansible-ssh/issues/4)), only required when the `ssh_known_hosts` list is used.
 
 ## Variables
 
@@ -65,6 +66,12 @@ Here is a list of all the default variables for this role, which are also availa
 #   Subsystem: sftp /usr/lib/openssh/sftp-server
 #
 
+# variable fallback defaults
+# usually overridden from Play or distro specific vars file
+ssh_config: {}
+ssh_packages: []
+ssh_service: sshd
+
 # DEPRICATION NOTICE:
 # use the `ssh_config` map @see var/DISTRIBUTION/VERSION.yml
 ssh_port: [22]
@@ -75,7 +82,7 @@ ssh_pubkey_authentication: 'yes'
 ssh_password_authentication: 'yes'
 
 # start on boot
-ssh_service_enabled: yes
+ssh_service_enabled: true
 # current state: started, stopped
 ssh_service_state: started
 # system wide known hosts
@@ -89,14 +96,13 @@ These are the handlers that are defined in `handlers/main.yml`.
 
 ```yaml
 ---
-# For more information about handlers see:
-# http://www.ansibleworks.com/docs/playbooks.html#handlers-running-operations-on-change
-#
+# handlers for ssh role
 
 - name: restart ssh
-  action: service name=ssh state=restarted
+  service:
+    name: "{{ ssh_service }}"
+    state: restarted
   when: ssh_service_state != 'stopped'
-
 ```
 
 
@@ -147,8 +153,6 @@ This is an example playbook:
       AcceptEnv: LANG LC_*
       Subsystem: sftp /usr/lib/openssh/sftp-server
       UsePAM: "yes"
-
-
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible weareinteractive.ssh role
 
 [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.org/weareinteractive/ansible-ssh)
-[![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/list#/roles/3275)
+[![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/weareinteractive/ssh)
 [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
 [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible weareinteractive.ssh role
 
-[![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.org/weareinteractive/ansible-ssh)
+[![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.com/weareinteractive/ansible-ssh)
 [![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/weareinteractive/ssh)
 [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
 [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)

--- a/meta/readme.yml
+++ b/meta/readme.yml
@@ -4,7 +4,7 @@ galaxy_name: weareinteractive.ssh
 github_user: weareinteractive
 github_name: ansible-ssh
 badges: |
-  [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.org/weareinteractive/ansible-ssh)
+  [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.com/weareinteractive/ansible-ssh)
   [![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/weareinteractive/ssh)
   [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
   [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)

--- a/meta/readme.yml
+++ b/meta/readme.yml
@@ -5,13 +5,13 @@ github_user: weareinteractive
 github_name: ansible-ssh
 badges: |
   [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ssh.svg)](https://travis-ci.org/weareinteractive/ansible-ssh)
-  [![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/list#/roles/3275)
+  [![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ssh-blue.svg)](https://galaxy.ansible.com/weareinteractive/ssh)
   [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
   [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-ssh.svg)](https://github.com/weareinteractive/ansible-ssh)
 description: |
-  > * installs ssh
-  > * configures ssh
-  > * adds logrotate for ssh container logs
+  > * Installs OpenSSH (if required)
+  > * Configures OpenSSH
+  > * Ensures OpenSSH is running and started on boot
 
   **Note:**
 


### PR DESCRIPTION
Travis CI now uses Python 3.8 instead of 2.7. Python 3 is often the default on many distributions nowadays and this takes care of the deprecation warnings at the same time.

The Travis CI script used a fixed name of `ansible-ssh` for the symlink to the role name. Matching this upstream repository, but not my fork. I modified the symlink to use the current working directory instead of the hard-coded path which solves this problem for my fork and possibly others who want to use a different name for their repository/fork.

Links to travis-ci.org have also been updated to the travis-ci.com domain. The travis-ci.org domain will cease to be at the end of this month (May 2021).