### PR TITLE
Fix OpenBSD wrong group set for template

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,6 +5,6 @@
     dest: /etc/ssh/sshd_config
     backup: true
     owner: root
-    group: root
+    group: "{{ sshd_config_group }} | default('root')"
     mode: "0644"
   notify: restart ssh

--- a/vars/openbsd.yml
+++ b/vars/openbsd.yml
@@ -2,6 +2,8 @@
 ssh_packages: []
 ssh_service: sshd
 
+sshd_config_group: 'wheel'
+
 ssh_config:
   PermitRootLogin: "no"
   AuthorizedKeysFile: .ssh/authorized_keys


### PR DESCRIPTION
Uh group `root` doesn't exist on OpenBSD, it's called `wheel`.
Tested it against a fresh machine and ran into that.