### PR TITLE
Fix variable precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.4.2"></a>
+### 1.4.2 (2022-05-12)
+
+#### Bug Fixes
+
+*   resolve issue with ssh_config variable precedence
+
+
 <a name="1.4.1"></a>
 ### 1.4.1 ()
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@
 
 # variable fallback defaults
 # usually overridden from Play or distro specific vars file
-ssh_config: {}
+ssh_config: "{{ ssh_config_default }}"
 ssh_packages: []
 ssh_service: sshd
 

--- a/vars/debian/bullseye.yml
+++ b/vars/debian/bullseye.yml
@@ -6,7 +6,7 @@ ssh_packages:
 
 ssh_service: ssh
 
-ssh_config:
+ssh_config_default:
   Include: /etc/ssh/sshd_config.d/*.conf
   ChallengeResponseAuthentication: "no"
   UsePAM: "yes"

--- a/vars/openbsd.yml
+++ b/vars/openbsd.yml
@@ -4,7 +4,7 @@ ssh_service: sshd
 
 sshd_config_group: 'wheel'
 
-ssh_config:
+ssh_config_default:
   PermitRootLogin: "no"
   AuthorizedKeysFile: .ssh/authorized_keys
   Subsystem: sftp /usr/libexec/sftp-server

--- a/vars/ubuntu/bionic.yml
+++ b/vars/ubuntu/bionic.yml
@@ -5,7 +5,7 @@ ssh_packages:
 
 ssh_service: ssh
 
-ssh_config:
+ssh_config_default:
   Port: "{{ ssh_port }}"
   ListenAddress: "{{ ssh_listen_address }}"
   PermitRootLogin: "{{ ssh_permit_root_login }}"

--- a/vars/ubuntu/trusty.yml
+++ b/vars/ubuntu/trusty.yml
@@ -5,7 +5,7 @@ ssh_packages:
 
 ssh_service: ssh
 
-ssh_config:
+ssh_config_default:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"
   ListenAddress: "{{ ssh_listen_address }}"

--- a/vars/ubuntu/xenial.yml
+++ b/vars/ubuntu/xenial.yml
@@ -5,7 +5,7 @@ ssh_packages:
 
 ssh_service: ssh
 
-ssh_config:
+ssh_config_default:
   Port: "{{ ssh_port }}"
   Protocol: "{{ ssh_protocol }}"
   ListenAddress: "{{ ssh_listen_address }}"


### PR DESCRIPTION
Defining `ssh_config` in your inventory did not take precedence over the
default defined in vars because of commit 000e104d3c. This commit fixes
that oversight by renaming the defaults to `ssh_config_default` and
importing the defaults via the `defaults/main.yml: ssh_config` variable.